### PR TITLE
feat: add test card alert and update README payment docs

### DIFF
--- a/client/src/app/(nondashboard)/checkout/payment/index.tsx
+++ b/client/src/app/(nondashboard)/checkout/payment/index.tsx
@@ -9,7 +9,7 @@ import { useCurrentCourse } from "@/hooks/useCurrentCourse";
 import { useCheckoutNavigation } from "@/hooks/useChekoutNavigation";
 import { useClerk, useUser } from "@clerk/nextjs";
 import CoursePreview from "@/components/CoursePreview";
-import { CreditCard } from "lucide-react";
+import { CreditCard, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import {
@@ -19,6 +19,7 @@ import {
 import { getCoursePath } from "@/lib/utils";
 import { useRouter } from "next/navigation";
 import Loading from "@/components/Loading";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 const PaymentPageContent = () => {
   const router = useRouter();
@@ -129,6 +130,15 @@ const PaymentPageContent = () => {
               <p className="payment__subtitle">
                 Fill out the payment details below to complete your purchase.
               </p>
+
+              <Alert className="border-primary-700">
+                <Info className="h-4 w-4" />
+                <AlertTitle>Heads Up!</AlertTitle>
+                <AlertDescription>
+                  Use card 4242 4242 4242 4242 with any future expiry/CVC for
+                  simulating successful payment.
+                </AlertDescription>
+              </Alert>
 
               <div className="payment__method">
                 <h3 className="payment__method-title">Payment Method</h3>

--- a/client/src/components/ui/alert.tsx
+++ b/client/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
- Add alert component with test card information (4242 4242 4242 4242)
- Add payment processing documentation to README
- Include platform screenshots in README
- Implement shadcn Alert component